### PR TITLE
Remove dependance on `core::fmt`

### DIFF
--- a/src/display/error.rs
+++ b/src/display/error.rs
@@ -29,7 +29,7 @@ where
         }
     }
 
-    /// Derive an `ErrorDisplay` from a [`fmt::Formatter`] with defaults.
+    /// Derive an `ErrorDisplay` from a [`fmt::FormatterBase`] with defaults.
     pub fn from_formatter<F>(error: &'a T, f: &F) -> Self
     where
         F: fmt::FormatterBase + ?Sized,
@@ -85,7 +85,7 @@ where
         F: fmt::FormatterBase + ?Sized,
     {
         f.write_str("error attempting to ")?;
-        f.write_display(&self.error.context_stack().root().operation())?;
+        f.write_str(self.error.context_stack().root().operation())?;
         f.write_str(": ")?;
         self.error.description(f.as_dyn_mut())?;
         f.write_char('\n')
@@ -238,11 +238,11 @@ where
 {
     input.prepare();
     f.write_str("> ")?;
-    fmt::DisplayBase::fmt(&input, f.as_dyn_mut())?;
+    f.write_display(&input)?;
     f.write_char('\n')?;
     if underline {
         f.write_str("  ")?;
-        fmt::DisplayBase::fmt(&input.underline(true), f.as_dyn_mut())?;
+        f.write_display(&input.underline(true))?;
         f.write_char('\n')?;
     }
     Ok(())

--- a/src/display/fmt.rs
+++ b/src/display/fmt.rs
@@ -1,0 +1,181 @@
+use core::fmt::{Debug, Display, Formatter};
+
+pub(crate) use core::fmt::{Error, Result, Write};
+
+pub(crate) struct Writer<'a, T: ?Sized>(&'a mut T);
+
+impl<'a, T: ?Sized> Writer<'a, T>
+where
+    T: FormatterBase,
+{
+    pub fn new(f: &'a mut T) -> Self {
+        Self(f)
+    }
+}
+
+impl<'a, T: ?Sized> Write for Writer<'a, T>
+where
+    T: FormatterBase,
+{
+    fn write_str(&mut self, s: &str) -> Result {
+        self.0.write_str(s)
+    }
+
+    fn write_char(&mut self, c: char) -> Result {
+        self.0.write_char(c)
+    }
+}
+
+pub trait FormatterBase {
+    fn as_dyn_mut(&mut self) -> &mut dyn FormatterBase;
+
+    fn alternate(&self) -> bool;
+    fn precision(&self) -> Option<usize>;
+
+    fn write_str(&mut self, s: &str) -> Result;
+    fn write_char(&mut self, c: char) -> Result;
+    fn write_usize(&mut self, v: usize) -> Result;
+    fn write_display(&mut self, v: &dyn DisplayBase) -> Result;
+
+    fn debug_str(&mut self, s: &str) -> Result;
+    fn debug_tuple(&mut self, name: &str, fields: &[&dyn DebugBase]) -> Result;
+    fn debug_struct(&mut self, name: &str, fields: &[(&'static str, &dyn DebugBase)]) -> Result;
+}
+
+impl<'a> FormatterBase for Formatter<'a> {
+    fn as_dyn_mut(&mut self) -> &mut dyn FormatterBase {
+        self
+    }
+
+    fn alternate(&self) -> bool {
+        Formatter::alternate(self)
+    }
+
+    fn precision(&self) -> Option<usize> {
+        Formatter::precision(self)
+    }
+
+    fn write_str(&mut self, s: &str) -> Result {
+        <Formatter<'_> as Write>::write_str(self, s)
+    }
+
+    fn write_char(&mut self, c: char) -> Result {
+        <Formatter<'_> as Write>::write_char(self, c)
+    }
+
+    fn write_usize(&mut self, v: usize) -> Result {
+        Display::fmt(&v, self)
+    }
+
+    fn write_display(&mut self, v: &dyn DisplayBase) -> Result {
+        DisplayBase::fmt(v, self)
+    }
+
+    fn debug_str(&mut self, s: &str) -> Result {
+        Debug::fmt(s, self)
+    }
+
+    fn debug_tuple(&mut self, name: &str, fields: &[&dyn DebugBase]) -> Result {
+        let mut debug = Formatter::debug_tuple(self, name);
+
+        struct Adapter<'a>(&'a dyn DebugBase);
+
+        impl<'a> Debug for Adapter<'a> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+                DebugBase::fmt(self.0, f)
+            }
+        }
+
+        for value in fields {
+            let _ = debug.field(&Adapter(*value));
+        }
+
+        debug.finish()
+    }
+
+    fn debug_struct(&mut self, name: &str, fields: &[(&'static str, &dyn DebugBase)]) -> Result {
+        let mut debug = Formatter::debug_struct(self, name);
+
+        struct Adapter<'a>(&'a dyn DebugBase);
+
+        impl<'a> Debug for Adapter<'a> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+                DebugBase::fmt(self.0, f)
+            }
+        }
+
+        for (name, value) in fields {
+            let _ = debug.field(name, &Adapter(*value));
+        }
+
+        debug.finish()
+    }
+}
+
+pub trait DebugBase {
+    fn fmt(&self, f: &mut dyn FormatterBase) -> Result;
+}
+
+impl DebugBase for usize {
+    fn fmt(&self, f: &mut dyn FormatterBase) -> Result {
+        f.write_usize(*self)
+    }
+}
+
+impl DebugBase for str {
+    fn fmt(&self, f: &mut dyn FormatterBase) -> Result {
+        f.debug_str(self)
+    }
+}
+
+impl<T> DebugBase for Option<T>
+where
+    T: DebugBase,
+{
+    fn fmt(&self, f: &mut dyn FormatterBase) -> Result {
+        match self {
+            None => f.debug_tuple("None", &[]),
+            Some(value) => f.debug_tuple("Some", &[value]),
+        }
+    }
+}
+
+impl DebugBase for core::num::NonZeroUsize {
+    fn fmt(&self, f: &mut dyn FormatterBase) -> Result {
+        f.debug_tuple("NonZeroUsize", &[&self.get()])
+    }
+}
+
+impl<T> DebugBase for &T
+where
+    T: DebugBase + ?Sized,
+{
+    fn fmt(&self, f: &mut dyn FormatterBase) -> Result {
+        (**self).fmt(f)
+    }
+}
+
+pub trait DisplayBase {
+    fn fmt(&self, f: &mut dyn FormatterBase) -> Result;
+}
+
+impl<T> DisplayBase for &T
+where
+    T: DisplayBase + ?Sized,
+{
+    fn fmt(&self, f: &mut dyn FormatterBase) -> Result {
+        (**self).fmt(f)
+    }
+}
+
+impl DisplayBase for str {
+    fn fmt(&self, f: &mut dyn FormatterBase) -> Result {
+        f.write_str(self)
+    }
+}
+
+impl DisplayBase for usize {
+    fn fmt(&self, f: &mut dyn FormatterBase) -> Result {
+        f.write_usize(*self)
+    }
+}

--- a/src/display/fmt.rs
+++ b/src/display/fmt.rs
@@ -2,30 +2,6 @@ use core::fmt::{Debug, Display, Formatter};
 
 pub(crate) use core::fmt::{Error, Result, Write};
 
-pub(crate) struct Writer<'a, T: ?Sized>(&'a mut T);
-
-impl<'a, T: ?Sized> Writer<'a, T>
-where
-    T: FormatterBase,
-{
-    pub fn new(f: &'a mut T) -> Self {
-        Self(f)
-    }
-}
-
-impl<'a, T: ?Sized> Write for Writer<'a, T>
-where
-    T: FormatterBase,
-{
-    fn write_str(&mut self, s: &str) -> Result {
-        self.0.write_str(s)
-    }
-
-    fn write_char(&mut self, c: char) -> Result {
-        self.0.write_char(c)
-    }
-}
-
 pub trait FormatterBase {
     fn as_dyn_mut(&mut self) -> &mut dyn FormatterBase;
 
@@ -112,6 +88,8 @@ impl<'a> FormatterBase for Formatter<'a> {
     }
 }
 
+///////////////////////////////////////////////////////////////////////////////
+
 pub trait DebugBase {
     fn fmt(&self, f: &mut dyn FormatterBase) -> Result;
 }
@@ -155,6 +133,9 @@ where
     }
 }
 
+///////////////////////////////////////////////////////////////////////////////
+
+///
 pub trait DisplayBase {
     fn fmt(&self, f: &mut dyn FormatterBase) -> Result;
 }
@@ -177,5 +158,31 @@ impl DisplayBase for str {
 impl DisplayBase for usize {
     fn fmt(&self, f: &mut dyn FormatterBase) -> Result {
         f.write_usize(*self)
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+pub(crate) struct Writer<'a, T: ?Sized>(&'a mut T);
+
+impl<'a, T: ?Sized> Writer<'a, T>
+where
+    T: FormatterBase,
+{
+    pub fn new(f: &'a mut T) -> Self {
+        Self(f)
+    }
+}
+
+impl<'a, T: ?Sized> Write for Writer<'a, T>
+where
+    T: FormatterBase,
+{
+    fn write_str(&mut self, s: &str) -> Result {
+        self.0.write_str(s)
+    }
+
+    fn write_char(&mut self, c: char) -> Result {
+        self.0.write_char(c)
     }
 }

--- a/src/display/input.rs
+++ b/src/display/input.rs
@@ -76,7 +76,7 @@ impl<'i> InputDisplay<'i> {
         }
     }
 
-    /// Derive an `InputDisplay` from a [`fmt::Formatter`] with defaults.
+    /// Derive an `InputDisplay` from a [`fmt::FormatterBase`] with defaults.
     ///
     /// - Precision (eg. `{:.16}`) formatting sets the element limit.
     /// - Alternate/pretty (eg. `{:#}`) formatting enables the UTF-8 hint.

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -1,7 +1,5 @@
 //! Display support.
 
-use core::fmt;
-
 mod error;
 mod input;
 mod section;
@@ -9,30 +7,24 @@ mod section_unit;
 mod unit;
 mod writer;
 
+pub(crate) mod fmt;
+
 pub use self::error::ErrorDisplay;
 pub use self::input::{InputDisplay, PreferredFormat};
 
 pub(crate) struct ByteCount(pub(crate) usize);
 
-impl fmt::Display for ByteCount {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl fmt::DisplayBase for ByteCount {
+    fn fmt(&self, f: &mut dyn fmt::FormatterBase) -> fmt::Result {
         match self.0 {
             0 => f.write_str("no bytes"),
             1 => f.write_str("1 byte"),
-            n => write!(f, "{} bytes", n),
+            n => {
+                f.write_usize(n)?;
+                f.write_str(" bytes")
+            }
         }
     }
 }
 
-struct WithFormatter<T>(T)
-where
-    T: Fn(&mut fmt::Formatter<'_>) -> fmt::Result;
-
-impl<T> fmt::Display for WithFormatter<T>
-where
-    T: Fn(&mut fmt::Formatter<'_>) -> fmt::Result,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        (self.0)(f)
-    }
-}
+forward_fmt!(impl Display for ByteCount);

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -10,12 +10,13 @@ mod writer;
 pub(crate) mod fmt;
 
 pub use self::error::ErrorDisplay;
+pub use self::fmt::{DebugBase, DisplayBase, FormatterBase};
 pub use self::input::{InputDisplay, PreferredFormat};
 
 pub(crate) struct ByteCount(pub(crate) usize);
 
-impl fmt::DisplayBase for ByteCount {
-    fn fmt(&self, f: &mut dyn fmt::FormatterBase) -> fmt::Result {
+impl DisplayBase for ByteCount {
+    fn fmt(&self, f: &mut dyn FormatterBase) -> fmt::Result {
         match self.0 {
             0 => f.write_str("no bytes"),
             1 => f.write_str("1 byte"),

--- a/src/display/section.rs
+++ b/src/display/section.rs
@@ -5,11 +5,12 @@
 // | head-tail | `"a" .. "a"` | `[97 .. 97]` | `['a' .. 'a']` |
 // | span      | `.. "a" ..`  | `[.. 97 ..]` | `[.. 'a' ..]`  |
 
-use core::{fmt, str};
+use core::str;
 
 use crate::util::alt_iter::{Alternate, AlternatingIter};
 use crate::util::{is_sub_slice, utf8};
 
+use super::fmt;
 use super::input::PreferredFormat;
 use super::section_unit::{ByteSectionUnitIter, CharSectionUnitIter, SectionUnit, SectionUnitIter};
 use super::writer::InputWriter;

--- a/src/display/unit.rs
+++ b/src/display/unit.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "unicode")]
 use unicode_width::UnicodeWidthChar;
 
-use core::fmt::{self, Write};
+use super::fmt::{self, Write};
 
 pub(super) fn byte_display_width(b: u8, show_ascii: bool) -> usize {
     if show_ascii {
@@ -28,10 +28,10 @@ pub(super) fn byte_display_write<W: Write>(b: u8, show_ascii: bool, w: &mut W) -
                 w.write_char(b as char)?;
                 w.write_char('\'')
             }
-            b => write!(w, "{:0>2x}", b),
+            b => write_hex_byte(w, b),
         }
     } else {
-        write!(w, "{:0>2x}", b)
+        write_hex_byte(w, b)
     }
 }
 
@@ -45,6 +45,18 @@ pub(super) fn char_display_write<W: Write>(c: char, w: &mut W) -> fmt::Result {
         w.write_char(c)?;
     }
     Ok(())
+}
+
+fn write_hex_byte<W: Write>(w: &mut W, b: u8) -> fmt::Result {
+    fn digit(b: u8) -> u8 {
+        match b {
+            x @ 0..=9 => b'0' + x,
+            x @ 10..=15 => b'a' + (x - 10),
+            _ => unreachable!(),
+        }
+    }
+    w.write_char(digit(b >> 4) as char)?;
+    w.write_char(digit(b & 0x0F) as char)
 }
 
 #[cfg(feature = "unicode")]

--- a/src/display/writer.rs
+++ b/src/display/writer.rs
@@ -1,5 +1,4 @@
-use core::fmt;
-
+use super::fmt;
 use super::unit::{byte_display_width, byte_display_write, char_display_width, char_display_write};
 
 pub(super) struct InputWriter<'a, W>

--- a/src/error/fatal.rs
+++ b/src/error/fatal.rs
@@ -1,5 +1,4 @@
-use core::fmt;
-
+use crate::display::fmt;
 use crate::input::Input;
 
 use super::{
@@ -32,17 +31,21 @@ use super::{
 #[derive(PartialEq)]
 pub struct Fatal;
 
-impl fmt::Debug for Fatal {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Fatal").finish()
+impl fmt::DebugBase for Fatal {
+    fn fmt(&self, f: &mut dyn fmt::FormatterBase) -> fmt::Result {
+        f.debug_tuple("Fatal", &[])
     }
 }
 
-impl fmt::Display for Fatal {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+forward_fmt!(impl Debug for Fatal);
+
+impl fmt::DisplayBase for Fatal {
+    fn fmt(&self, f: &mut dyn fmt::FormatterBase) -> fmt::Result {
         f.write_str("invalid input")
     }
 }
+
+forward_fmt!(impl Display for Fatal);
 
 impl<'i> FromContext<'i> for Fatal {
     fn from_context<C>(self, _input: Input<'i>, _context: C) -> Self

--- a/src/error/invalid.rs
+++ b/src/error/invalid.rs
@@ -1,5 +1,4 @@
-use core::fmt;
-
+use crate::display::fmt;
 use crate::input::Input;
 
 use super::{
@@ -44,16 +43,16 @@ impl Invalid {
     }
 }
 
-impl fmt::Debug for Invalid {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Invalid")
-            .field("retry_requirement", &self.retry_requirement)
-            .finish()
+impl fmt::DebugBase for Invalid {
+    fn fmt(&self, f: &mut dyn fmt::FormatterBase) -> fmt::Result {
+        f.debug_struct("Invalid", &[("retry_requirement", &self.retry_requirement)])
     }
 }
 
-impl fmt::Display for Invalid {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+forward_fmt!(impl Debug for Invalid);
+
+impl fmt::DisplayBase for Invalid {
+    fn fmt(&self, f: &mut dyn fmt::FormatterBase) -> fmt::Result {
         f.write_str("invalid input")?;
         if let Some(retry_requirement) = self.retry_requirement {
             f.write_str(": needs ")?;
@@ -63,6 +62,8 @@ impl fmt::Display for Invalid {
         Ok(())
     }
 }
+
+forward_fmt!(impl Display for Invalid);
 
 impl ToRetryRequirement for Invalid {
     #[inline(always)]

--- a/src/error/retry.rs
+++ b/src/error/retry.rs
@@ -1,7 +1,6 @@
-use core::fmt;
 use core::num::NonZeroUsize;
 
-use crate::display::ByteCount;
+use crate::display::{fmt, ByteCount};
 
 /// An indicator of how many bytes are required to continue processing input.
 ///
@@ -48,17 +47,22 @@ impl RetryRequirement {
     }
 }
 
-impl fmt::Debug for RetryRequirement {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("RetryRequirement").field(&self.0).finish()
+impl fmt::DebugBase for RetryRequirement {
+    fn fmt(&self, f: &mut dyn fmt::FormatterBase) -> fmt::Result {
+        f.debug_tuple("RetryRequirement", &[&self.0])
     }
 }
 
-impl fmt::Display for RetryRequirement {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} more", ByteCount(self.continue_after()))
+forward_fmt!(impl Debug for RetryRequirement);
+
+impl fmt::DisplayBase for RetryRequirement {
+    fn fmt(&self, f: &mut dyn fmt::FormatterBase) -> fmt::Result {
+        ByteCount(self.continue_after()).fmt(f)?;
+        f.write_str(" more")
     }
 }
+
+forward_fmt!(impl Display for RetryRequirement);
 
 /// Implemented for errors that return a [`RetryRequirement`].
 pub trait ToRetryRequirement {

--- a/src/error/traits.rs
+++ b/src/error/traits.rs
@@ -1,5 +1,4 @@
-use core::fmt;
-
+use crate::display::fmt;
 use crate::input::Input;
 
 use super::{Context, ContextStack, ExpectedLength, ExpectedValid, ExpectedValue};
@@ -62,7 +61,7 @@ pub trait Details<'i> {
     /// # Errors
     ///
     /// Returns a [`fmt::Error`] if failed to write to the formatter.
-    fn description(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
+    fn description(&self, f: &mut dyn fmt::FormatterBase) -> fmt::Result;
 
     /// The walkable [`ContextStack`] to the original context around the error
     /// that occurred.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2,8 +2,9 @@ mod internal;
 
 use core::convert::Infallible;
 use core::ops::Range;
-use core::{fmt, str};
+use core::str;
 
+use crate::display::fmt;
 use crate::display::InputDisplay;
 use crate::error::{ExpectedContext, ExpectedLength, ExpectedValid, FromContext, OperationContext};
 use crate::reader::Reader;
@@ -373,18 +374,22 @@ impl<'i> PartialEq<Input<'i>> for [u8] {
 ///////////////////////////////////////////////////////////////////////////////
 // Formatting
 
-impl<'i> fmt::Debug for Input<'i> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl<'i> fmt::DebugBase for Input<'i> {
+    fn fmt(&self, f: &mut dyn fmt::FormatterBase) -> fmt::Result {
         let display = InputDisplay::from_formatter(self, f);
-        f.debug_tuple("Input").field(&display).finish()
+        f.debug_tuple("Input", &[&display])
     }
 }
 
-impl<'i> fmt::Display for Input<'i> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+forward_fmt!(impl<'i> Debug for Input<'i>);
+
+impl<'i> fmt::DisplayBase for Input<'i> {
+    fn fmt(&self, f: &mut dyn fmt::FormatterBase) -> fmt::Result {
         InputDisplay::from_formatter(self, f).fmt(f)
     }
 }
+
+forward_fmt!(impl<'i> Display for Input<'i>);
 
 ///////////////////////////////////////////////////////////////////////////////
 // Clone

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -35,8 +35,8 @@ pub const fn input(bytes: &[u8]) -> Input<'_> {
 ///
 /// # Formatting
 ///
-/// `Input` implements both [`fmt::Debug`] and [`fmt::Display`] with support for
-/// pretty printing. See [`InputDisplay`] for formatting options.
+/// `Input` implements both [`core::fmt::Debug`] and [`core::fmt::Display`] with
+/// support for pretty printing. See [`InputDisplay`] for formatting options.
 ///
 /// [`dangerous::input()`]: crate::input()
 #[must_use = "input must be consumed"]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -81,3 +81,34 @@ macro_rules! split_arr {
         $input.split_arr_8($expected)
     };
 }
+
+macro_rules! forward_fmt {
+    (impl Debug for $name:ident) => {
+        impl core::fmt::Debug for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                crate::display::fmt::DebugBase::fmt(self, f)
+            }
+        }
+    };
+    (impl Display for $name:ident) => {
+        impl core::fmt::Display for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                crate::display::fmt::DisplayBase::fmt(self, f)
+            }
+        }
+    };
+    (impl<$($impl_generics:tt),+> Debug for $name:ident<$($ty_generics:tt),+> $(where $bname:tt:$bvalue:tt$(<$($b_generics:tt),+>)?)?) => {
+        impl<$($impl_generics),+> core::fmt::Debug for $name<$($ty_generics),+> $(where $bname:$bvalue$(<$($b_generics),+>)?)? {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                crate::display::fmt::DebugBase::fmt(self, f)
+            }
+        }
+    };
+    (impl<$($impl_generics:tt),+> Display for $name:ident<$($ty_generics:tt),+> $(where $bname:tt:$bvalue:tt$(<$($b_generics:tt),+>)?)?) => {
+        impl<$($impl_generics),+> core::fmt::Display for $name<$($ty_generics),+> $(where $bname:$bvalue$(<$($b_generics),+>)?)? {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                crate::display::fmt::DisplayBase::fmt(self, f)
+            }
+        }
+    };
+}

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,6 +1,6 @@
-use core::fmt;
 use core::marker::PhantomData;
 
+use crate::display::fmt;
 use crate::error::{
     with_context, Context, ExpectedLength, ExpectedValid, ExpectedValue, FromContext,
     OperationContext, ToRetryRequirement,
@@ -629,10 +629,10 @@ impl<'i, E> Reader<'i, E> {
     }
 }
 
-impl<'i, E> fmt::Debug for Reader<'i, E> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Reader")
-            .field("input", &self.input)
-            .finish()
+impl<'i, E> fmt::DebugBase for Reader<'i, E> {
+    fn fmt(&self, f: &mut dyn fmt::FormatterBase) -> fmt::Result {
+        f.debug_struct("Reader", &[("input", &self.input)])
     }
 }
+
+forward_fmt!(impl<'i, E> Debug for Reader<'i, E>);


### PR DESCRIPTION
Closes #10 

Exception of `core::fmt::Write`.