### PR TITLE
Add initial zc support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ zc = { version = "0.2", optional = true, default-features = false }
 bytecount = { version = "0.6", optional = true }
 unicode-width = { version = "0.1", optional = true }
 
+[dev-dependencies]
+zc = "0.2"
+
 [[example]]
 name = "json"
 required-features = ["std"]
@@ -36,6 +39,10 @@ required-features = ["std"]
 [[example]]
 name = "streaming"
 required-features = ["std"]
+
+[[example]]
+name = "zerocopy"
+required-features = ["zc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ unicode = ["unicode-width"]
 full-context = ["alloc"]
 
 [dependencies]
-zc = { git = "https://github.com/avitex/rust-zc", default-features = false, optional = true }
+zc = { version = "0.2", optional = true, default-features = false }
 bytecount = { version = "0.6", optional = true }
 unicode-width = { version = "0.1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ unicode = ["unicode-width"]
 full-context = ["alloc"]
 
 [dependencies]
+zc = { git = "https://github.com/avitex/rust-zc", default-features = false, optional = true }
 bytecount = { version = "0.6", optional = true }
 unicode-width = { version = "0.1", optional = true }
 

--- a/examples/zerocopy.rs
+++ b/examples/zerocopy.rs
@@ -1,0 +1,32 @@
+use dangerous::{Expected, Reader};
+use zc::Dependant;
+
+#[derive(Dependant, Debug)]
+pub struct ParsedResult<'a>(Result<Vec<&'a str>, Expected<'a>>);
+
+impl<'a> From<&'a [u8]> for ParsedResult<'a> {
+    fn from(bytes: &'a [u8]) -> Self {
+        let input = dangerous::input(bytes);
+        Self(input.read_all(parse))
+    }
+}
+
+fn main() {
+    let buf = Vec::from(&b"thisisatag,thisisanothertag"[..]);
+    let parsed = zc::from!(buf, ParsedResult, [u8]);
+    dbg!(parsed);
+}
+
+fn parse<'i, E>(r: &mut Reader<'i, E>) -> Result<Vec<&'i str>, E>
+where
+    E: dangerous::Error<'i>,
+{
+    let mut parts = Vec::new();
+    loop {
+        let s = r.take_while(|b| b != b',').to_dangerous_str::<E>()?;
+        parts.push(s);
+        if !r.consume_u8_opt(b',') {
+            return Ok(parts);
+        }
+    }
+}

--- a/src/error/context.rs
+++ b/src/error/context.rs
@@ -132,6 +132,9 @@ impl fmt::Debug for ExpectedContext {
     }
 }
 
+#[cfg(feature = "zc")]
+unsafe impl zc::NoInteriorMut for ExpectedContext {}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Operation context
 
@@ -161,6 +164,9 @@ impl fmt::Debug for OperationContext {
         f.debug_tuple("OperationContext").field(&self.0).finish()
     }
 }
+
+#[cfg(feature = "zc")]
+unsafe impl zc::NoInteriorMut for OperationContext {}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Root context stack
@@ -195,6 +201,9 @@ impl ContextStack for RootContextStack {
         f(1, &self.context)
     }
 }
+
+#[cfg(feature = "zc")]
+unsafe impl zc::NoInteriorMut for RootContextStack {}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Full context stack
@@ -245,6 +254,9 @@ impl ContextStack for FullContextStack {
         f(i, &self.root)
     }
 }
+
+#[cfg(feature = "zc")]
+unsafe impl zc::NoInteriorMut for FullContextStack {}
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/src/error/expected.rs
+++ b/src/error/expected.rs
@@ -251,6 +251,9 @@ where
 #[cfg(feature = "std")]
 impl<'i, S> std::error::Error for Expected<'i, S> where S: ContextStack {}
 
+#[cfg(feature = "zc")]
+unsafe impl<'i, S> zc::NoInteriorMut for Expected<'i, S> where S: zc::NoInteriorMut {}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Expected value error
 
@@ -332,6 +335,9 @@ impl<'i> ToRetryRequirement for ExpectedValue<'i> {
         self.input.is_bound() || !self.expected().has_prefix(self.found().as_dangerous())
     }
 }
+
+#[cfg(feature = "zc")]
+unsafe impl<'i> zc::NoInteriorMut for ExpectedValue<'i> {}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Expected length error
@@ -476,6 +482,9 @@ impl<'i> ToRetryRequirement for ExpectedLength<'i> {
     }
 }
 
+#[cfg(feature = "zc")]
+unsafe impl<'i> zc::NoInteriorMut for ExpectedLength<'i> {}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Expected valid error
 
@@ -555,6 +564,9 @@ impl<'i> ToRetryRequirement for ExpectedValid<'i> {
         self.input.is_bound() || self.retry_requirement.is_some()
     }
 }
+
+#[cfg(feature = "zc")]
+unsafe impl<'i> zc::NoInteriorMut for ExpectedValid<'i> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/error/fatal.rs
+++ b/src/error/fatal.rs
@@ -86,3 +86,6 @@ impl<'i> From<ExpectedValid<'i>> for Fatal {
         Self
     }
 }
+
+#[cfg(feature = "zc")]
+unsafe impl zc::NoInteriorMut for Fatal {}

--- a/src/error/invalid.rs
+++ b/src/error/invalid.rs
@@ -128,3 +128,6 @@ impl From<Option<RetryRequirement>> for Invalid {
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Invalid {}
+
+#[cfg(feature = "zc")]
+unsafe impl zc::NoInteriorMut for Invalid {}

--- a/src/error/retry.rs
+++ b/src/error/retry.rs
@@ -72,6 +72,9 @@ impl fmt::Display for RetryRequirement {
     }
 }
 
+#[cfg(feature = "zc")]
+unsafe impl zc::NoInteriorMut for RetryRequirement {}
+
 /// Implemented for errors that return a [`RetryRequirement`].
 pub trait ToRetryRequirement {
     /// Returns the requirement, if applicable, to retry processing the `Input`.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -414,3 +414,9 @@ impl<'i> Clone for Input<'i> {
         }
     }
 }
+
+///////////////////////////////////////////////////////////////////////////////
+// Zc
+
+#[cfg(feature = "zc")]
+unsafe impl<'i> zc::NoInteriorMut for Input<'i> {}

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -729,3 +729,6 @@ impl<'i, E> fmt::Debug for Reader<'i, E> {
             .finish()
     }
 }
+
+#[cfg(feature = "zc")]
+unsafe impl<'i, E> zc::NoInteriorMut for Reader<'i, E> {}


### PR DESCRIPTION
- Implements `zc::NoInteriorMut` for types.