### PR TITLE
Add internal string flag

### DIFF
--- a/src/input/flags.rs
+++ b/src/input/flags.rs
@@ -1,0 +1,49 @@
+const TAG_BOUND: u8 = 0b1000_0000;
+const TAG_ISSTR: u8 = 0b0100_0000;
+
+#[derive(Copy, Clone)]
+pub(super) struct Flags(u8);
+
+impl Default for Flags {
+    #[inline(always)]
+    fn default() -> Self {
+        Self::new(false, false)
+    }
+}
+
+impl Flags {
+    #[inline(always)]
+    pub(super) const fn new(bound: bool, is_str: bool) -> Self {
+        Self(0).bound(bound).str(is_str)
+    }
+
+    #[inline]
+    pub(super) const fn is_bound(self) -> bool {
+        self.0 & TAG_BOUND == TAG_BOUND
+    }
+
+    #[inline]
+    pub(super) const fn is_str(self) -> bool {
+        self.0 & TAG_ISSTR == TAG_ISSTR
+    }
+
+    #[inline(always)]
+    pub(super) const fn bound(mut self, value: bool) -> Self {
+        self.0 = if value {
+            self.0 | TAG_BOUND
+        } else {
+            self.0 & !TAG_BOUND
+        };
+        self
+    }
+
+    #[inline(always)]
+    pub(super) const fn str(mut self, value: bool) -> Self {
+        self.0 = if value {
+            self.0 | TAG_ISSTR
+        } else {
+            self.0 & !TAG_ISSTR
+        };
+        self
+    }
+}

--- a/src/input/internal.rs
+++ b/src/input/internal.rs
@@ -7,7 +7,7 @@ use crate::error::{
 use crate::reader::Reader;
 use crate::util::{byte, slice};
 
-use super::Input;
+use super::{Flags, Input};
 
 // All functions defined in internal are used within other functions that expose
 // public functionality.
@@ -22,7 +22,23 @@ use super::Input;
 impl<'i> Input<'i> {
     #[inline(always)]
     pub(crate) const fn new(bytes: &'i [u8], bound: bool) -> Self {
-        Self { bytes, bound }
+        Self {
+            bytes,
+            flags: Flags::new(bound, false),
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) const fn new_str(s: &'i str, bound: bool) -> Self {
+        Self {
+            bytes: s.as_bytes(),
+            flags: Flags::new(bound, true),
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) const fn is_str(&self) -> bool {
+        self.flags.is_str()
     }
 
     #[inline(always)]


### PR DESCRIPTION
- Adds a flag internally for `Input` to work out whether it is known as a `str` or not.