### PR TITLE
Support retrying to_dangerous_str

### DIFF
--- a/src/input/bytes.rs
+++ b/src/input/bytes.rs
@@ -87,7 +87,8 @@ impl<'i> Bytes<'i> {
     ///
     /// # Errors
     ///
-    /// Returns [`ExpectedValid`] if the input is not valid UTF-8.
+    /// Returns [`ExpectedValid`] if the input could never be valid UTF-8 and
+    /// [`ExpectedLength`] if a UTF-8 code point was cut short.
     #[inline(always)]
     pub fn to_dangerous_str<E>(&self) -> Result<&'i str, E>
     where
@@ -155,7 +156,8 @@ impl<'i> Bytes<'i> {
     ///
     /// # Errors
     ///
-    /// Returns [`ExpectedValid`] if the input is not valid UTF-8.
+    /// Returns [`ExpectedValid`] if the input could never be valid UTF-8 and
+    /// [`ExpectedLength`] if a UTF-8 code point was cut short.
     #[inline(always)]
     pub fn into_string<E>(self) -> Result<String<'i>, E>
     where

--- a/src/input/string.rs
+++ b/src/input/string.rs
@@ -89,31 +89,9 @@ impl<'i> String<'i> {
     pub fn from_utf8<E>(utf8: Bytes<'i>) -> Result<String<'i>, E>
     where
         E: From<ExpectedValid<'i>>,
+        E: From<ExpectedLength<'i>>,
     {
-        let bytes = utf8.as_dangerous();
-        match str::from_utf8(bytes) {
-            Ok(s) => Ok(String::new(s, utf8.bound())),
-            Err(utf8_err) => {
-                let valid_up_to = utf8_err.valid_up_to();
-                let span = match utf8_err.error_len() {
-                    Some(error_len) => {
-                        let error_end = valid_up_to + error_len;
-                        &bytes[valid_up_to..error_end]
-                    }
-                    None => &bytes[valid_up_to..],
-                };
-                Err(E::from(ExpectedValid {
-                    span,
-                    input: utf8.into_maybe_string(),
-                    context: ExpectedContext {
-                        operation: "convert input to str",
-                        expected: "utf-8 code point",
-                    },
-                    #[cfg(feature = "retry")]
-                    retry_requirement: None,
-                }))
-            }
-        }
+        utf8.into_string()
     }
 
     /// Construct a `String` from unchecked [`Bytes`].

--- a/src/input/string.rs
+++ b/src/input/string.rs
@@ -85,7 +85,8 @@ impl<'i> String<'i> {
     ///
     /// # Errors
     ///
-    /// Returns [`ExpectedValid`] if the input is not valid UTF-8.
+    /// Returns [`ExpectedValid`] if the input could never be valid UTF-8 and
+    /// [`ExpectedLength`] if a UTF-8 code point was cut short.
     pub fn from_utf8<E>(utf8: Bytes<'i>) -> Result<String<'i>, E>
     where
         E: From<ExpectedValid<'i>>,

--- a/src/input/traits.rs
+++ b/src/input/traits.rs
@@ -402,6 +402,7 @@ pub(crate) trait PrivateExt<'i>: Input<'i> {
         F: FnOnce(&mut Reader<'i, E, Self>),
     {
         let mut reader = Reader::new(self.clone());
+        // Consume input.
         f(&mut reader);
         // We take the remaining input.
         let tail = reader.take_remaining();
@@ -434,7 +435,8 @@ pub(crate) trait PrivateExt<'i>: Input<'i> {
         F: FnOnce(&mut Reader<'i, E, Self>) -> Result<(), E>,
     {
         let mut reader = Reader::new(self.clone());
-        with_context(self.clone(), OperationContext(operation), || f(&mut reader))?;
+        // Consume input.
+        reader.context(OperationContext(operation), f)?;
         // We take the remaining input.
         let tail = reader.take_remaining();
         // For the head, we take what we consumed.
@@ -513,7 +515,7 @@ pub(crate) trait PrivateExt<'i>: Input<'i> {
             operation,
         };
         let mut reader = Reader::new(self.clone());
-        match with_context(self.clone(), context, || f(&mut reader)) {
+        match reader.context(context, f) {
             Ok(Some(ok)) => Ok((ok, reader.take_remaining())),
             Ok(None) => {
                 let tail = reader.take_remaining();

--- a/src/reader/bytes.rs
+++ b/src/reader/bytes.rs
@@ -14,7 +14,6 @@ impl<'i, E> BytesReader<'i, E> {
     /// [`ExpectedLength`] if a UTF-8 code point was cut short.
     pub fn skip_str_while<F>(&mut self, pred: F) -> Result<usize, E>
     where
-        E: WithContext<'i>,
         E: From<ExpectedValid<'i>>,
         E: From<ExpectedLength<'i>>,
         F: FnMut(char) -> bool,
@@ -53,7 +52,6 @@ impl<'i, E> BytesReader<'i, E> {
     #[inline]
     pub fn take_remaining_str(&mut self) -> Result<String<'i>, E>
     where
-        E: WithContext<'i>,
         E: From<ExpectedValid<'i>>,
         E: From<ExpectedLength<'i>>,
     {
@@ -68,7 +66,6 @@ impl<'i, E> BytesReader<'i, E> {
     /// [`ExpectedLength`] if a UTF-8 code point was cut short.
     pub fn take_str_while<F>(&mut self, pred: F) -> Result<String<'i>, E>
     where
-        E: WithContext<'i>,
         E: From<ExpectedValid<'i>>,
         E: From<ExpectedLength<'i>>,
         F: FnMut(char) -> bool,

--- a/src/reader/input.rs
+++ b/src/reader/input.rs
@@ -59,7 +59,6 @@ where
     /// Read a length of input that was successfully consumed from a sub-parse.
     pub fn take_consumed<F>(&mut self, consumer: F) -> I
     where
-        E: WithContext<'i>,
         F: FnOnce(&mut Self),
     {
         self.advance(|input| input.split_consumed(consumer))
@@ -152,7 +151,6 @@ where
     pub fn expect<F, T>(&mut self, expected: &'static str, f: F) -> Result<T, E>
     where
         F: FnOnce(&mut Self) -> Option<T>,
-        E: WithContext<'i>,
         E: From<ExpectedValid<'i>>,
     {
         self.try_advance(|input| input.split_expect(f, expected, "expect"))

--- a/tests/test_errors.rs
+++ b/tests/test_errors.rs
@@ -444,6 +444,12 @@ fn test_invalid_error_details_span() {
         }
     }
 
+    impl<'i> From<ExpectedLength<'i>> for MyError {
+        fn from(err: ExpectedLength<'i>) -> Self {
+            Self(RootContextStack::from_root(err.context()))
+        }
+    }
+
     impl<'i> Details<'i> for MyError {
         fn input(&self) -> MaybeString<'i> {
             input!(b"something").into_maybe_string()

--- a/tests/test_input.rs
+++ b/tests/test_input.rs
@@ -92,37 +92,14 @@ fn test_to_dangerous_str_expected_length() {
     let err = input!(&[0b1101_1111])
         .to_dangerous_str::<Expected>()
         .unwrap_err();
-    assert_eq!(err.to_retry_requirement(), None);
+    assert_eq!(err.to_retry_requirement(), RetryRequirement::new(1));
     // Length 3
     let err = input!(&[0b1110_1111])
         .to_dangerous_str::<Expected>()
         .unwrap_err();
-    assert_eq!(err.to_retry_requirement(), None);
+    assert_eq!(err.to_retry_requirement(), RetryRequirement::new(2));
     // Invalid
     let err = input!(&[0b1111_0111])
-        .to_dangerous_str::<Expected>()
-        .unwrap_err();
-    assert_eq!(err.to_retry_requirement(), None);
-}
-
-#[test]
-fn test_to_dangerous_str_expected_length_fatal() {
-    // Length 1
-    input!(&[0b0111_1111, b'a'])
-        .to_dangerous_str::<Expected>()
-        .unwrap();
-    // Length 2
-    let err = input!(&[0b1101_1111, b'a'])
-        .to_dangerous_str::<Expected>()
-        .unwrap_err();
-    assert_eq!(err.to_retry_requirement(), None);
-    // Length 3
-    let err = input!(&[0b1110_1111, b'a'])
-        .to_dangerous_str::<Expected>()
-        .unwrap_err();
-    assert_eq!(err.to_retry_requirement(), None);
-    // Invalid
-    let err = input!(&[0b1111_0111, b'a'])
         .to_dangerous_str::<Expected>()
         .unwrap_err();
     assert_eq!(err.to_retry_requirement(), None);


### PR DESCRIPTION
Made this fatal before because I wasn't confident in input bounding, re-introducing it as a potentially retryable operation.