### PR TITLE
 Fix examples to pass `#![deny(rust_2018_idioms)]`

### DIFF
--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -4,7 +4,7 @@ use dangerous::{BytesReader, Error, Expected, Input, Invalid};
 
 fn main() {
     let input = dangerous::input(b"192.168.1.x");
-    let error: Expected = input.read_all(read_ipv4_addr).unwrap_err();
+    let error: Expected<'_> = input.read_all(read_ipv4_addr).unwrap_err();
 
     println!("{:#}", error);
 }

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -3,14 +3,14 @@ use dangerous::{Expected, Input};
 fn main() {
     // Expect length
     dbg!(&dangerous::input(b"A\xC3\xA9 \xC2")
-        .to_dangerous_str::<Expected>()
+        .to_dangerous_str::<Expected<'_>>()
         .unwrap_err());
     // Expect valid
     dbg!(&dangerous::input(b"A\xC3\xA9 \xFF")
-        .to_dangerous_str::<Expected>()
+        .to_dangerous_str::<Expected<'_>>()
         .unwrap_err());
     // Expect value
     dbg!(&dangerous::input(b"hello")
-        .read_all::<_, _, Expected>(|r| r.consume(b"world"))
+        .read_all::<_, _, Expected<'_>>(|r| r.consume(b"world"))
         .unwrap_err());
 }

--- a/examples/ini.rs
+++ b/examples/ini.rs
@@ -14,7 +14,7 @@ fn main() {
         .read_to_end(&mut input_data)
         .expect("read input");
     let input = dangerous::input(input_data.as_slice());
-    match input.read_all::<_, _, Expected>(read_ini) {
+    match input.read_all::<_, _, Expected<'_>>(read_ini) {
         Ok(ini) => println!("{:#?}", ini),
         Err(e) => eprintln!("{:#}", e),
     };
@@ -132,7 +132,7 @@ enum ConsumeTo {
 }
 
 fn skip_whitespace_or_comment<E>(r: &mut BytesReader<'_, E>, to_where: ConsumeTo) {
-    fn skip_comment<E>(r: &mut BytesReader<E>) -> usize {
+    fn skip_comment<E>(r: &mut BytesReader<'_, E>) -> usize {
         if r.peek_eq(b';') {
             r.take_while(|c| c != b'\n').len()
         } else {


### PR DESCRIPTION
This would make the examples consistent with the requirements for code within the crate itself.

Please feel free to close if examples should rather remain a little more readable/less overwhelming by leaving out anonymous lifetime annotations.